### PR TITLE
re #15719 - Add "Georgian" as a language on educations.com

### DIFF
--- a/schemas/2.0/language.xsd
+++ b/schemas/2.0/language.xsd
@@ -53,6 +53,10 @@
       <xs:enumeration value="Thai" />
       <xs:enumeration value="Tibetan" />
       <xs:enumeration value="Urdu" />
+	  <xs:enumeration value="Khmer" />
+	  <xs:enumeration value="Turkish" />
+	  <xs:enumeration value="Vietnamese" />	  
+	  <xs:enumeration value="Georgian" />
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/schemas/3.0/language.xsd
+++ b/schemas/3.0/language.xsd
@@ -53,6 +53,10 @@
       <xs:enumeration value="Thai" />
       <xs:enumeration value="Tibetan" />
       <xs:enumeration value="Urdu" />
+	  <xs:enumeration value="Khmer" />
+	  <xs:enumeration value="Turkish" />
+	  <xs:enumeration value="Vietnamese" />	  
+	  <xs:enumeration value="Georgian" />
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/sdks/dotnet/src/2.0/Types/EMG.XML.Types.csproj
+++ b/sdks/dotnet/src/2.0/Types/EMG.XML.Types.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.3;netstandard2.0;net40</TargetFrameworks>
     <RootNamespace>EMG.XML</RootNamespace>
     <PackageId>EMG.XML.Types</PackageId>
-    <PackageVersion>2.1.0.0-preview.5</PackageVersion>
+    <PackageVersion>2.1.0.0-preview.6</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdks/dotnet/src/2.0/Types/Language.cs
+++ b/sdks/dotnet/src/2.0/Types/Language.cs
@@ -99,6 +99,15 @@ namespace EMG.XML
 
         [XmlEnum] Tibetan,
 
-        [XmlEnum] Urdu
+        [XmlEnum] Urdu,
+
+        [XmlEnum] Khmer,
+
+        [XmlEnum] Turkish,
+
+        [XmlEnum] Vietnamese,
+
+        [XmlEnum] Georgian
+
     }
 }

--- a/sdks/dotnet/src/3.0/Types/EMG.XML.Types.csproj
+++ b/sdks/dotnet/src/3.0/Types/EMG.XML.Types.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.3;netstandard2.0;net40</TargetFrameworks>
     <RootNamespace>EMG.XML</RootNamespace>
     <PackageId>EMG.XML.Types</PackageId>
-    <PackageVersion>3.1.0.0-preview.5</PackageVersion>
+    <PackageVersion>3.1.0.0-preview.6</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdks/dotnet/src/3.0/Types/Language.cs
+++ b/sdks/dotnet/src/3.0/Types/Language.cs
@@ -99,6 +99,14 @@ namespace EMG.XML
 
         [XmlEnum] Tibetan,
 
-        [XmlEnum] Urdu
+        [XmlEnum] Urdu,
+
+        [XmlEnum] Khmer,
+
+        [XmlEnum] Turkish,
+
+        [XmlEnum] Vietnamese,
+
+        [XmlEnum] Georgian
     }
 }


### PR DESCRIPTION
Added Georgian (and missing Khmer, Turkish and Vietnamese) to xml import schemas 2.0 and 3.0