### PR TITLE
remove provider self inclusion

### DIFF
--- a/schemas/3.0/provider.xsd
+++ b/schemas/3.0/provider.xsd
@@ -6,7 +6,6 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:tp="http://educations.com/XmlImport/Text-Property"
 >
-  <xs:include schemaLocation="provider.xsd" />
   <xs:include schemaLocation="course.xsd" />
   <xs:include schemaLocation="location.xsd" />
   <xs:include schemaLocation="course-text-property.xsd" />


### PR DESCRIPTION
xmllint fails to parse the xsd schema if a schema includes itself.

```
xml-import-master/schemas/3.0/provider.xsd:9: element include: Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}include': The schema document 'xml-import-master/schemas/3.0/provider.xsd' cannot include itself..
WXS schema xml-import-master/schemas/3.0/xml-import.xsd failed to compile
```